### PR TITLE
Documentation fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
 DATABASE_URL=''
-#DATABASE_URL="file:./db.sqlite"
+# DATABASE_URL='postgresql://root@localhost:26257/sdc?application_name=%24+cockroach+sql&connect_timeout=15&sslmode=disable'
 
 # Next Auth
 # You can generate a new secret on the command line with:

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ yarn.lock
 #python venv
 venv/
 src/server/scraper/scrape.py
+
+#docker compose link directory
+cockroachdb/

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Thank you for considering contributing to SDC-v3! This project is open to contri
 To get started, follow these steps:
 
 1. Fork the repository and clone it to your local machine.
-2. Install the necessary dependencies using `npm install`.
-3. Create a new branch for your changes using `git checkout -b new-branch-name`.
-4. Make your changes and commit them using `git commit`.
-5. Push your changes to your fork using `git push origin new-branch-name`.
-6. Open a pull request on the main repository.
+1. Install the necessary dependencies using `npm install`.
+1. Check the `docs/local-db-setup.md` instructions to setup the CockroachDB database.
+1. Create a new branch for your changes using `git checkout -b new-branch-name`.
+1. Make your changes and commit them using `git commit` Push your changes to your fork using `git push origin new-branch-name`.
+1. Open a pull request on the main repository.
 
 ## Guidelines
 
@@ -28,11 +28,12 @@ Here are a few guidelines to follow when contributing:
 To contribute to this project, follow these steps:
 
 1. Fork this repository by clicking the "Fork" button at the top of the repository page.
-2. Clone the forked repository to your local machine using the command git clone <forked-repo-url>.
-3. Create a new branch for your changes using the command git checkout -b <new-branch-name>.
+2. Clone the forked repository to your local machine using the command `git clone <forked-repo-url>`.
+2. Setup the dev database based on instructions present on `docs/local-db-setup.md`.
+3. Create a new branch for your changes using the command `git checkout -b <new-branch-name>`.
 4. Make the necessary changes to the code, and make sure they follow the project's coding style and conventions.
-5. Commit your changes with a descriptive commit message using the command git commit -m "Descriptive commit message".
-6. Push your changes to your forked repository using the command git push origin <new-branch-name>.
+5. Commit your changes with a descriptive commit message using the `command git commit -m "Descriptive commit message"`.
+6. Push your changes to your forked repository using the command `git push origin <new-branch-name>`.
 7. Create a pull request by clicking the "New pull request" button on the forked repository page.
 8. Wait for the project maintainers to review your pull request and provide feedback.
 9. Make any necessary changes based on the feedback, and push them to your branch.
@@ -40,11 +41,15 @@ To contribute to this project, follow these steps:
 
 To link a pull request from a forked repository to the original repository's issue, you can use a special syntax in the pull request's description or comments. Here are the steps to do this:
 
-1. In the pull request's description or comments, type "Fixes #issue-number", where "issue-number" is the number of the issue in the original repository that the pull request is related to.
-2. Make sure the issue number is preceded by the "#" symbol. For example, if the issue number is "123", you would type "Fixes #123".
+1. In the pull request's description or comments, type `Fixes #<issue-number>`, where `issue-number` is the number of the issue in the original repository that the pull request is related to.
+2. Make sure the issue number is preceded by the `#` symbol. For example, if the issue number is `123`, you would type `Fixes #123`.
 3. When you submit the pull request, GitHub will automatically link the pull request to the issue in the original repository.
-4. The pull request will also appear in the "Pull requests" tab of the original repository's issue.
+4. The pull request will also appear in the `Pull requests` tab of the original repository's issue.
 5. Here's an example of what the syntax would look like in a pull request comment:
+
+```
+This PR is for this issue and fixes #123
+```
 
 ## Code of Conduct
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,2 +1,0 @@
-CREATE DATABASE sdc_migrations;
-GRANT CREATE, ALTER, DROP, REFERENCES ON sdc_migrations.* TO sdc@'%';

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,20 +1,19 @@
 version: "3.8"
 
 services:
-  mysql:
-    image: mysql
-    command: --default-authentication-plugin=caching_sha2_password
+  db:
+    image: cockroachdb/cockroach:latest
+    command: start-single-node --insecure
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: sdc_root_password
-      MYSQL_DATABASE: sdc
-      MYSQL_USER: sdc
-      MYSQL_PASSWORD: sdc_password
+      COCKROACH_DATABASE: sdc
+      COCKROACH_USER: sdc
+      COCKROACH_PASSWORD: sdc_password
     volumes:
-      - db:/var/lib/mysql
-      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ${PWD}/cockroachdb:/cockroach/cockroach-data
     ports:
-      - "3306:3306"
+      - "26257:26257"
+      - "8080:8080"
 
 volumes:
-  db:
+  cockroachdb:

--- a/docs/local-db-setup.md
+++ b/docs/local-db-setup.md
@@ -1,4 +1,4 @@
-# Setting up MySQL Instance with Docker Compose
+# Setting up CockroachDB instance with Docker Compose
 
 ## Prerequisites
 Before getting started, ensure that you have the following prerequisites installed on your machine:
@@ -13,13 +13,13 @@ Before getting started, ensure that you have the following prerequisites install
 
 2. Navigate to the `sdc` project directory where you'll find the `docker-compose.dev.yml` file.
 
-3. Run the following command to start the MySQL container:
+3. Run the following command to start the CockroachDB container:
 
     ```shell
     docker compose -f docker-compose.dev.yml -up -d
     ```
 
-4. Wait for Docker to download the MySQL image and start the container. You can check the container status by running the command:
+4. Wait for Docker to download the CockraochDB image and start the container. You can check the container status by running the command:
 
     ```shell
     docker compose -f docker-compose.dev.yml ps
@@ -28,19 +28,19 @@ Before getting started, ensure that you have the following prerequisites install
     You should see an output similar to the following:
 
     ```shell
-    NAME                COMMAND                  SERVICE             STATUS              PORTS
-    sdc-v3-mysql-1      "docker-entrypoint.s…"   mysql               running             0.0.0.0:3306->3306/tcp
+    NAME                COMMAND                        SERVICE             STATUS              PORTS
+    sdc-v3      "docker-entrypoint.s…"   cockroachdb/cockroach         running             0.0.0.0:8080->8080/tcp,0.0.0.0:26257->26257/tcp
     ```
 
-5. Once the container is up and running, you can connect to the MySQL instance using a MySQL client tool of your choice. Here's an example using the `mysql` command-line client:
+5. Once the container is up and running, you can connect to the CockroachDB instance using a client tool of your choice. Here's an example using the `sql` command-line client within the comtainer:
 
     ```shell
-    mysql -h localhost -P 3306 -u sdc -p
+    ./cockroach sql --insecure
     ```
 
 You will be prompted to enter the password. Enter `sdc_password`.
 
-6. Congratulations! You are now connected to the MySQL instance and ready to work with the `sdc` database.
+6. Congratulations! You are now connected to the CockroachDB instance and ready to work with the `sdc` database.
 
 ### Windows
 
@@ -48,13 +48,13 @@ You will be prompted to enter the password. Enter `sdc_password`.
 
 2. Navigate to the `sdc` project directory where you'll find the `docker-compose.dev.yml` file.
 
-3. Run the following command to start the MySQL container:
+3. Run the following command to start the CockroachDB container:
 
     ```shell
     docker compose -f docker-compose.dev.yml -up -d
     ```
 
-4. Wait for Docker to download the MySQL image and start the container. You can check the container status by running the command:
+4. Wait for Docker to download the CockroachDB image and start the container. You can check the container status by running the command:
 
     ```shell
     docker compose -f docker-compose.dev.yml ps
@@ -67,15 +67,19 @@ See macOS instructions above.
 
 ## Connecting sdc website to the DB
 
-Update the values of `DATABASE_URL` and `SHADOW_DATABASE_URL` in your `.env` file to the following:
+Update the values of `DATABASE_URL` in your `.env` file to the following:
 
 ```
-DATABASE_URL='mysql://sdc:sdc_password@localhost:3306/sdc'
-SHADOW_DATABASE_URL='mysql://sdc:sdc_password@localhost:3306/sdc_migrations'
+DATABASE_URL='postgresql://root@localhost:26257/sdc?application_name=%24+cockroach+sql&connect_timeout=15&sslmode=disable'
+
 ```
 
-Then run prisma migrations to apply schema changes to the newly created DB
+Then run prisma client generation, run migrations and seed the db to apply schema changes to the newly created DB to begin development
 
 ```shell
+npx prisma generate 
+
 npx prisma migrate dev
+
+npx prisma db seed
 ```


### PR DESCRIPTION
This PR is for fixing #68 

Foxed outdated documentation for -

- Readme with updated steps for Contributing section, Getting Started section
- Updated documentation references to move form mysql to cockroachDb (current db deployment)
- Fixes in `docker-compose.dev.yml` file for new devs to setup and get started easily
- Fixes for `docs/local-mysql-with-docker-compose.md `to `docs/local-db-setup.md` with updated instructions for dev setup, migration, seeding, etc.
Discard `db/init.sql` as no longer required

All documentation has been manually verified and docker compose fixes have been tested to run effectively. kindly approve on verification. @ScottDavis08 or @Emmanuel96 